### PR TITLE
Add board configs for BrewTroller phoenix

### DIFF
--- a/build-all-test.sh
+++ b/build-all-test.sh
@@ -64,7 +64,11 @@ board_list=("BT_3X"\
             "OT_EX1_HERMS"\        
             "OT_EX1_RIMSDF"\       
             "OT_EX1_SINGLEVESSEL"\ 
-            "OT_EX1_STEAMPWM")     
+            "OT_EX1_STEAMPWM"\
+            "BT_PHOENIX_HERMS"\
+            "BT_PHOENIX_RIMS"\
+            "BT_PHOENIX_SINGLE_VESSEL"\
+            "BT_PHOENIX_STEAM_PWM")     
 
 for board in "${board_list[@]}"
 do

--- a/options.json
+++ b/options.json
@@ -19,10 +19,10 @@
 			{"optName":"OT_EX1_RIMSDF", "name": "EX1 RIMS"},
 			{"optName":"OT_EX1_SINGLEVESSEL", "name": "EX1 Single Vessel"},
 			{"optName":"OT_EX1_STEAMPWM", "name": "EX1 Steam"},
-                        {"optName":"BT_PHOENIX","name": "Phoenix HERMS"},
-                        {"optName":"BT_PHOENIX","name": "Phoenix RIMS"},
-                        {"optName":"BT_PHOENIX","name": "Phoenix Single Vessel"},
-                        {"optName":"BT_PHOENIX","name": "Phoenix Steam"}
+                        {"optName":"BT_PHOENIX_HERMS","name": "Phoenix HERMS"},
+                        {"optName":"BT_PHOENIX_RIMS","name": "Phoenix RIMS"},
+                        {"optName":"BT_PHOENIX_SINGLEVESSEL","name": "Phoenix Single Vessel"},
+                        {"optName":"BT_PHOENIX_STEAMPWM","name": "Phoenix Steam"}
                 ],
 		"default": "Phoenix HERMS"
 	},

--- a/options.json
+++ b/options.json
@@ -18,9 +18,13 @@
 			{"optName":"OT_EX1_HERMS", "name": "EX1 HERMS"},
 			{"optName":"OT_EX1_RIMSDF", "name": "EX1 RIMS"},
 			{"optName":"OT_EX1_SINGLEVESSEL", "name": "EX1 Single Vessel"},
-			{"optName":"OT_EX1_STEAMPWM", "name": "EX1 Steam"}
+			{"optName":"OT_EX1_STEAMPWM", "name": "EX1 Steam"},
+                        {"optName":"BT_PHOENIX","name": "Phoenix HERMS"},
+                        {"optName":"BT_PHOENIX","name": "Phoenix RIMS"},
+                        {"optName":"BT_PHOENIX","name": "Phoenix Single Vessel"},
+                        {"optName":"BT_PHOENIX","name": "Phoenix Steam"},
 		],
-		"default": "DX1 HERMS"
+		"default": "Phoenix HERMS"
 	},
 	{
 		"type": "switch",

--- a/options.json
+++ b/options.json
@@ -22,8 +22,8 @@
                         {"optName":"BT_PHOENIX","name": "Phoenix HERMS"},
                         {"optName":"BT_PHOENIX","name": "Phoenix RIMS"},
                         {"optName":"BT_PHOENIX","name": "Phoenix Single Vessel"},
-                        {"optName":"BT_PHOENIX","name": "Phoenix Steam"},
-		],
+                        {"optName":"BT_PHOENIX","name": "Phoenix Steam"}
+                ],
 		"default": "Phoenix HERMS"
 	},
 	{

--- a/options.json
+++ b/options.json
@@ -1,67 +1,67 @@
  [
-	{
-		"type": "radio",
-		"id": "board",
-		"title": "Board Type",
-		"description": "Select the physical BrewTroller board type you have",
-		"options": [
-			{"optName":"BT_3X", "name": "3.X"},
-			{"optName":"BT_4P", "name": "4.X Pro"},
-			{"optName":"OT_BX1_HERMSI2CLCD", "name": "BX1 HERMS"},
-			{"optName":"OT_BX1_RIMSDFI2CLCD", "name": "BX1 RIMS"},
-			{"optName":"OT_BX1_SINGLEVESSEL", "name": "BX1 Single Vessel"},
-			{"optName":"OT_BX1_STEAMPWMI2CLCD", "name": "BX1 Steam"},
-			{"optName":"OT_DX1_HERMS", "name": "DX1 HERMS"},
-			{"optName":"OT_DX1_RIMSDF", "name": "DX1 RIMS"},
-			{"optName":"OT_DX1_SINGLEVESSEL", "name": "DX1 Single Vessel"},
-			{"optName":"OT_DX1_STEAMPWM", "name": "DX1 Steam"},
-			{"optName":"OT_EX1_HERMS", "name": "EX1 HERMS"},
-			{"optName":"OT_EX1_RIMSDF", "name": "EX1 RIMS"},
-			{"optName":"OT_EX1_SINGLEVESSEL", "name": "EX1 Single Vessel"},
-			{"optName":"OT_EX1_STEAMPWM", "name": "EX1 Steam"},
-                        {"optName":"BT_PHOENIX_HERMS","name": "Phoenix HERMS"},
-                        {"optName":"BT_PHOENIX_RIMS","name": "Phoenix RIMS"},
-                        {"optName":"BT_PHOENIX_SINGLEVESSEL","name": "Phoenix Single Vessel"},
-                        {"optName":"BT_PHOENIX_STEAMPWM","name": "Phoenix Steam"}
-                ],
-		"default": "Phoenix HERMS"
-	},
-	{
-		"type": "switch",
-		"id": "BASIC_CONFIG",
-		"title": "Basic Configuration",
-		"description": "Basic BrewTroller Configuration Options.",
-		"options": [
-			{"name": "Use Metric Units", "optName":"USEMETRIC", "on": false}
-		]
-	},
-	{
-		"type": "switch",
-		"id": "VESSEL_CONFIG",
-		"title": "Vessel Configuration",
-		"description": "Configure Vessel Use and Type Options for your Brewery",
-		"options": [
-			{"name": "Use HLT as Kettle", "optName": "HLT_AS_KETTLE", "on": false},
-			{"name": "Use Kettle as Mash", "optName": "KETTLE_AS_MASH", "on": false},
-			{"name": "Single Vessel Mode", "optName": "SINGLE_VESSEL_SUPPORT", "on": false}
-		]
-	},
-	{
-		"type": "switch",
-		"id": "VOLUME_SENSORS",
-		"title": "Volume Sensing",
-		"description": "Disabling volume sensors changes the system display screens; Instead of displaying current volume levels target volumes for the step are shown",
-		"options": [
-			{"name": "Disable Volume Sensors", "optName":"VOLUME_MANUAL", "on": false}
-		]
-	},
-	{
-		"type": "switch",
-		"id": "SKIP_TO_BOIL",
-		"title": "Skip To Boil",
-		"description": "When enabled, all program steps preceeding boil are skipped. Useful for controlling boil stage only.",
-		"options": [
-			{"name": "Boil Only", "optName":"AUTO_SKIP_TO_BOIL", "on": false}
-		]
-	}
+    {
+        "type": "radio",
+        "id": "board",
+        "title": "Board Type",
+        "description": "Select the physical BrewTroller board type you have",
+        "options": [
+            {"optName":"BT_3X", "name": "3.X"},
+            {"optName":"BT_4P", "name": "4.X Pro"},
+            {"optName":"OT_BX1_HERMSI2CLCD", "name": "BX1 HERMS"},
+            {"optName":"OT_BX1_RIMSDFI2CLCD", "name": "BX1 RIMS"},
+            {"optName":"OT_BX1_SINGLEVESSEL", "name": "BX1 Single Vessel"},
+            {"optName":"OT_BX1_STEAMPWMI2CLCD", "name": "BX1 Steam"},
+            {"optName":"OT_DX1_HERMS", "name": "DX1 HERMS"},
+            {"optName":"OT_DX1_RIMSDF", "name": "DX1 RIMS"},
+            {"optName":"OT_DX1_SINGLEVESSEL", "name": "DX1 Single Vessel"},
+            {"optName":"OT_DX1_STEAMPWM", "name": "DX1 Steam"},
+            {"optName":"OT_EX1_HERMS", "name": "EX1 HERMS"},
+            {"optName":"OT_EX1_RIMSDF", "name": "EX1 RIMS"},
+            {"optName":"OT_EX1_SINGLEVESSEL", "name": "EX1 Single Vessel"},
+            {"optName":"OT_EX1_STEAMPWM", "name": "EX1 Steam"},
+            {"optName":"BT_PHOENIX_HERMS","name": "Phoenix HERMS"},
+            {"optName":"BT_PHOENIX_RIMS","name": "Phoenix RIMS"},
+            {"optName":"BT_PHOENIX_SINGLEVESSEL","name": "Phoenix Single Vessel"},
+            {"optName":"BT_PHOENIX_STEAMPWM","name": "Phoenix Steam"}
+            ],
+        "default": "Phoenix HERMS"
+    },
+    {
+        "type": "switch",
+        "id": "BASIC_CONFIG",
+        "title": "Basic Configuration",
+        "description": "Basic BrewTroller Configuration Options.",
+        "options": [
+            {"name": "Use Metric Units", "optName":"USEMETRIC", "on": false}
+        ]
+    },
+    {
+        "type": "switch",
+        "id": "VESSEL_CONFIG",
+        "title": "Vessel Configuration",
+        "description": "Configure Vessel Use and Type Options for your Brewery",
+        "options": [
+            {"name": "Use HLT as Kettle", "optName": "HLT_AS_KETTLE", "on": false},
+            {"name": "Use Kettle as Mash", "optName": "KETTLE_AS_MASH", "on": false},
+            {"name": "Single Vessel Mode", "optName": "SINGLE_VESSEL_SUPPORT", "on": false}
+        ]
+    },
+    {
+        "type": "switch",
+        "id": "VOLUME_SENSORS",
+        "title": "Volume Sensing",
+        "description": "Disabling volume sensors changes the system display screens; Instead of displaying current volume levels target volumes for the step are shown",
+        "options": [
+            {"name": "Disable Volume Sensors", "optName":"VOLUME_MANUAL", "on": false}
+        ]
+    },
+    {
+        "type": "switch",
+        "id": "SKIP_TO_BOIL",
+        "title": "Skip To Boil",
+        "description": "When enabled, all program steps preceeding boil are skipped. Useful for controlling boil stage only.",
+        "options": [
+            {"name": "Boil Only", "optName":"AUTO_SKIP_TO_BOIL", "on": false}
+        ]
+    }
 ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,25 +50,29 @@ message(STATUS "Building BrewTroller version: " ${VER_STR})
 # User selectable compile time options
 ####################
 set(board  "OT_DX1_HERMS" CACHE STRING "BrewTroller Hardware Board Target, available options:
-BT_10_21               --> 1.0 - 2.1
-BT_22_24               --> 2.2 - 2.4
-BT_3X                  --> 3.X
-BT_4P                  --> 4.X Pro
-OT_BX1_HERMS           --> BX1 HERMS
-OT_BX1_HERMSI2CLCD     --> BX1 HERMS + I2CLCD
-OT_BX1_RIMSDF          --> BX1 RIMS / Direct Fired
-OT_BX1_RIMSDFI2CLCD    --> BX1 RIMS / Direct Fired + I2CLCD
-OT_BX1_SINGLEVESSEL    --> BX1 Single Vessel
-OT_BX1_STEAMPWM        --> BX1 Steam or PWM Pump
-OT_BX1_STEAMPWMI2CLCD  --> BX1 Steam or PWM Pump + I2CLCD
-OT_DX1_HERMS           --> DX1 HERMS
-OT_DX1_RIMSDF          --> DX1 RIMS / Direct Fired
-OT_DX1_SINGLEVESSEL    --> DX1 Single Vessel
-OT_DX1_STEAMPWM        --> DX1 Steam or PWM Pump
-OT_EX1_HERMS           --> EX1 HERMS
-OT_EX1_RIMSDF          --> EX1 RIMS / Direct Fired
-OT_EX1_SINGLEVESSEL    --> EX1 Single Vessel
-OT_EX1_STEAMPWM        --> EX1 Steam or PWM Pump") # Default to DX1 Herms build
+BT_10_21                 --> 1.0 - 2.1
+BT_22_24                 --> 2.2 - 2.4
+BT_3X                    --> 3.X
+BT_4P                    --> 4.X Pro
+OT_BX1_HERMS             --> BX1 HERMS
+OT_BX1_HERMSI2CLCD       --> BX1 HERMS + I2CLCD
+OT_BX1_RIMSDF            --> BX1 RIMS / Direct Fired
+OT_BX1_RIMSDFI2CLCD      --> BX1 RIMS / Direct Fired + I2CLCD
+OT_BX1_SINGLEVESSEL      --> BX1 Single Vessel
+OT_BX1_STEAMPWM          --> BX1 Steam or PWM Pump
+OT_BX1_STEAMPWMI2CLCD    --> BX1 Steam or PWM Pump + I2CLCD
+OT_DX1_HERMS             --> DX1 HERMS
+OT_DX1_RIMSDF            --> DX1 RIMS / Direct Fired
+OT_DX1_SINGLEVESSEL      --> DX1 Single Vessel
+OT_DX1_STEAMPWM          --> DX1 Steam or PWM Pump
+OT_EX1_HERMS             --> EX1 HERMS
+OT_EX1_RIMSDF            --> EX1 RIMS / Direct Fired
+OT_EX1_SINGLEVESSEL      --> EX1 Single Vessel
+OT_EX1_STEAMPWM          --> EX1 Steam or PWM Pump
+BT_PHOENIX_HERMS         --> Phoenix HERMS
+BT_PHOENIX_RIMS          --> Phoenix RIMS
+BT_PHOENIX_SINGLE_VESSEL --> Phoenix Single Vessel
+BT_PHOENIX_STEAM_PWM     --> Phoenix Steam or PWM Pump") # Default to DX1 Herms build
 add_definitions("-D${board}")
 message(STATUS "Building BrewTroller for   " ${board})
 

--- a/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h
@@ -1,0 +1,121 @@
+/*
+BrewTroller Phoenix HERMS Hardware Configuration
+*/
+
+#ifndef __BREWTROLLER_HWPROFILE__
+    #error "Include HardwareProfile.h instead of this file"
+#endif
+
+#ifndef BT_HWPROFILE
+#define BT_HWPROFILE
+
+  #define ENCODER_I2C
+  #define ENCODER_I2CADDR 0x01
+
+  #define ALARM_PIN 15 //OUT4
+  
+  #define PVOUT_TYPE_MUX
+  #define PVOUT_COUNT 16 //16 Outputs
+
+  #define MUX_LATCH_PIN 3
+  #define MUX_CLOCK_PIN 4
+  #define MUX_DATA_PIN 1
+  #define MUX_ENABLE_PIN 2
+  #define MUX_ENABLE_LOGIC 0
+  
+  #define HLTHEAT_PIN 12
+  #define KETTLEHEAT_PIN 14
+
+  #define DIGITAL_INPUTS
+  #define DIGIN_COUNT 8
+  #define DIGIN1_PIN 31
+  #define DIGIN2_PIN 30
+  #define DIGIN3_PIN 29
+  #define DIGIN4_PIN 28
+  #define DIGIN5_PIN 18
+  #define DIGIN6_PIN 19
+  #define DIGIN7_PIN 20
+  #define DIGIN8_PIN 21
+
+  #define RS485_SERIAL_PORT 1
+  #define RS485_RTS_PIN    23
+  #define PVOUT_TYPE_MODBUS
+  
+  #define HLTVOL_APIN 7
+  #define MASHVOL_APIN 6
+  #define KETTLEVOL_APIN 5
+  #define STEAMPRESS_APIN 4
+  
+  #define UI_LCD_I2C
+  #define UI_LCD_I2CADDR 0x01
+  #define UI_DISPLAY_SETUP
+  #define LCD_DEFAULT_CONTRAST 100
+  #define LCD_DEFAULT_BRIGHTNESS 255
+  
+  // BTPD_SUPPORT: Enables use of BrewTroller PID Display devices on I2C bus
+  #define BTPD_SUPPORT
+  
+  // BTNIC_EMBEDDED: Enables use of on-board I2C Ethernet module
+  #define BTNIC_EMBEDDED
+  
+  #define HEARTBEAT
+  #define HEARTBEAT_PIN 0
+
+  //**********************************************************************************
+  // OneWire Temperature Sensor Options
+  //**********************************************************************************
+  // TS_ONEWIRE: Enables use of OneWire Temperature Sensors
+  // TS_ONEWIRE_I2C: Enables use of DS2482 I2C 1-Wire Bus Master
+  #define TS_ONEWIRE
+  #define TS_ONEWIRE_I2C
+  
+  // TS_ONEWIRE_PPWR: Specifies whether parasite power is used for OneWire temperature
+  // sensors. Parasite power allows sensors to obtain their power from the data line
+  // but significantly increases the time required to read the temperature (94-750ms
+  // based on resolution versus 10ms with dedicated power).
+  #define TS_ONEWIRE_PPWR 0
+  
+  // TS_ONEWIRE_RES: OneWire Temperature Sensor Resolution (9-bit - 12-bit). Valid
+  // options are: 9, 10, 11, 12). Unless parasite power is being used the recommended
+  // setting is 12-bit (for DS18B20 sensors). DS18S20 sensors can only operate at a max
+  // of 9 bit. When using parasite power decreasing the resolution reduces the 
+  // temperature conversion time: 
+  //   12-bit (0.0625C / 0.1125F) = 750ms 
+  //   11-bit (0.125C  / 0.225F ) = 375ms 
+  //   10-bit (0.25C   / 0.45F  ) = 188ms 
+  //    9-bit (0.5C    / 0.9F   ) =  94ms   
+  #define TS_ONEWIRE_RES 11
+  
+  // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
+  // 2 bytes of temperature data and ignoring CRC check.
+  #define TS_ONEWIRE_FASTREAD
+  
+  // DS2482_ADDR: I2C Address of DS2482 OneWire Master (used for TS_OneWire_I2C)
+  // Should be 0x18, 0x19, 0x1A, 0x1B
+  #define DS2482_ADDR 0x1B
+  //**********************************************************************************
+
+
+  //**********************************************************************************
+  // Serial0 Communication Options
+  //**********************************************************************************
+  // COM_SERIAL0: Specifies the communication type being used (Pick One):
+  //  ASCII  = Original BrewTroller serial command protocol used with BTRemote and BTLog
+  //  BTNIC  = BTnic (Lighterweight implementation of ASCII protocol using single-byte
+  //           commands. This protocol is used with BTnic Modules and software for
+  //           network connectivity.
+  //  BINARY = Binary Messages
+  //**********************************************************************************
+  
+  //#define COM_SERIAL0  ASCII
+  #define COM_SERIAL0  BTNIC
+  //#define COM_SERIAL0 BINARY
+  
+  // BAUD_RATE: The baud rate for the Serial0 connection. Previous to BrewTroller 2.0
+  // Build 419 this was hard coded to 9600. Starting with Build 419 the default rate
+  // was increased to 115200 but can be manually set using this compile option.
+  #define SERIAL0_BAUDRATE 115200
+
+#endif
+
+

--- a/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h
@@ -1,0 +1,122 @@
+/*
+BrewTroller Phoenix RIMS/Direct Fired Hardware Configuration
+*/
+
+#ifndef __BREWTROLLER_HWPROFILE__
+    #error "Include HardwareProfile.h instead of this file"
+#endif
+
+#ifndef BT_HWPROFILE
+#define BT_HWPROFILE
+
+  #define ENCODER_I2C
+  #define ENCODER_I2CADDR 0x01
+
+  #define ALARM_PIN 15 //OUT4
+  
+  #define PVOUT_TYPE_MUX
+  #define PVOUT_COUNT 16 //16 Outputs
+
+  #define MUX_LATCH_PIN 3
+  #define MUX_CLOCK_PIN 4
+  #define MUX_DATA_PIN 1
+  #define MUX_ENABLE_PIN 2
+  #define MUX_ENABLE_LOGIC 0
+  
+  #define HLTHEAT_PIN 12
+  #define MASHHEAT_PIN 13
+  #define KETTLEHEAT_PIN 14
+
+  #define DIGITAL_INPUTS
+  #define DIGIN_COUNT 8
+  #define DIGIN1_PIN 31
+  #define DIGIN2_PIN 30
+  #define DIGIN3_PIN 29
+  #define DIGIN4_PIN 28
+  #define DIGIN5_PIN 18
+  #define DIGIN6_PIN 19
+  #define DIGIN7_PIN 20
+  #define DIGIN8_PIN 21
+
+  #define RS485_SERIAL_PORT 1
+  #define RS485_RTS_PIN    23
+  #define PVOUT_TYPE_MODBUS
+  
+  #define HLTVOL_APIN 7
+  #define MASHVOL_APIN 6
+  #define KETTLEVOL_APIN 5
+  #define STEAMPRESS_APIN 4
+  
+  #define UI_LCD_I2C
+  #define UI_LCD_I2CADDR 0x01
+  #define UI_DISPLAY_SETUP
+  #define LCD_DEFAULT_CONTRAST 100
+  #define LCD_DEFAULT_BRIGHTNESS 255
+  
+  // BTPD_SUPPORT: Enables use of BrewTroller PID Display devices on I2C bus
+  #define BTPD_SUPPORT
+  
+  // BTNIC_EMBEDDED: Enables use of on-board I2C Ethernet module
+  #define BTNIC_EMBEDDED
+  
+  #define HEARTBEAT
+  #define HEARTBEAT_PIN 0
+
+  //**********************************************************************************
+  // OneWire Temperature Sensor Options
+  //**********************************************************************************
+  // TS_ONEWIRE: Enables use of OneWire Temperature Sensors
+  // TS_ONEWIRE_I2C: Enables use of DS2482 I2C 1-Wire Bus Master
+  #define TS_ONEWIRE
+  #define TS_ONEWIRE_I2C
+  
+  // TS_ONEWIRE_PPWR: Specifies whether parasite power is used for OneWire temperature
+  // sensors. Parasite power allows sensors to obtain their power from the data line
+  // but significantly increases the time required to read the temperature (94-750ms
+  // based on resolution versus 10ms with dedicated power).
+  #define TS_ONEWIRE_PPWR 0
+  
+  // TS_ONEWIRE_RES: OneWire Temperature Sensor Resolution (9-bit - 12-bit). Valid
+  // options are: 9, 10, 11, 12). Unless parasite power is being used the recommended
+  // setting is 12-bit (for DS18B20 sensors). DS18S20 sensors can only operate at a max
+  // of 9 bit. When using parasite power decreasing the resolution reduces the 
+  // temperature conversion time: 
+  //   12-bit (0.0625C / 0.1125F) = 750ms 
+  //   11-bit (0.125C  / 0.225F ) = 375ms 
+  //   10-bit (0.25C   / 0.45F  ) = 188ms 
+  //    9-bit (0.5C    / 0.9F   ) =  94ms   
+  #define TS_ONEWIRE_RES 11
+  
+  // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
+  // 2 bytes of temperature data and ignoring CRC check.
+  #define TS_ONEWIRE_FASTREAD
+  
+  // DS2482_ADDR: I2C Address of DS2482 OneWire Master (used for TS_OneWire_I2C)
+  // Should be 0x18, 0x19, 0x1A, 0x1B
+  #define DS2482_ADDR 0x1B
+  //**********************************************************************************
+
+
+  //**********************************************************************************
+  // Serial0 Communication Options
+  //**********************************************************************************
+  // COM_SERIAL0: Specifies the communication type being used (Pick One):
+  //  ASCII  = Original BrewTroller serial command protocol used with BTRemote and BTLog
+  //  BTNIC  = BTnic (Lighterweight implementation of ASCII protocol using single-byte
+  //           commands. This protocol is used with BTnic Modules and software for
+  //           network connectivity.
+  //  BINARY = Binary Messages
+  //**********************************************************************************
+  
+  //#define COM_SERIAL0  ASCII
+  #define COM_SERIAL0  BTNIC
+  //#define COM_SERIAL0 BINARY
+  
+  // BAUD_RATE: The baud rate for the Serial0 connection. Previous to BrewTroller 2.0
+  // Build 419 this was hard coded to 9600. Starting with Build 419 the default rate
+  // was increased to 115200 but can be manually set using this compile option.
+  #define SERIAL0_BAUDRATE 115200
+
+#endif
+
+

--- a/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h
@@ -1,0 +1,120 @@
+/*
+BrewTroller Phoenix Single Vessel Hardware Configuration
+*/
+
+#ifndef __BREWTROLLER_HWPROFILE__
+    #error "Include HardwareProfile.h instead of this file"
+#endif
+
+#ifndef BT_HWPROFILE
+#define BT_HWPROFILE
+
+  #define ENCODER_I2C
+  #define ENCODER_I2CADDR 0x01
+
+  #define ALARM_PIN 15 //OUT4
+  
+  #define PVOUT_TYPE_MUX
+  #define PVOUT_COUNT 16 //16 Outputs
+
+  #define MUX_LATCH_PIN 3
+  #define MUX_CLOCK_PIN 4
+  #define MUX_DATA_PIN 1
+  #define MUX_ENABLE_PIN 2
+  #define MUX_ENABLE_LOGIC 0
+  
+  #define HLTHEAT_PIN 12
+
+  #define DIGITAL_INPUTS
+  #define DIGIN_COUNT 8
+  #define DIGIN1_PIN 31
+  #define DIGIN2_PIN 30
+  #define DIGIN3_PIN 29
+  #define DIGIN4_PIN 28
+  #define DIGIN5_PIN 18
+  #define DIGIN6_PIN 19
+  #define DIGIN7_PIN 20
+  #define DIGIN8_PIN 21
+
+  #define RS485_SERIAL_PORT 1
+  #define RS485_RTS_PIN    23
+  #define PVOUT_TYPE_MODBUS
+  
+  #define HLTVOL_APIN 7
+  #define MASHVOL_APIN 6
+  #define KETTLEVOL_APIN 5
+  #define STEAMPRESS_APIN 4
+  
+  #define UI_LCD_I2C
+  #define UI_LCD_I2CADDR 0x01
+  #define UI_DISPLAY_SETUP
+  #define LCD_DEFAULT_CONTRAST 100
+  #define LCD_DEFAULT_BRIGHTNESS 255
+  
+  // BTPD_SUPPORT: Enables use of BrewTroller PID Display devices on I2C bus
+  #define BTPD_SUPPORT
+  
+  // BTNIC_EMBEDDED: Enables use of on-board I2C Ethernet module
+  #define BTNIC_EMBEDDED
+  
+  #define HEARTBEAT
+  #define HEARTBEAT_PIN 0
+
+  //**********************************************************************************
+  // OneWire Temperature Sensor Options
+  //**********************************************************************************
+  // TS_ONEWIRE: Enables use of OneWire Temperature Sensors
+  // TS_ONEWIRE_I2C: Enables use of DS2482 I2C 1-Wire Bus Master
+  #define TS_ONEWIRE
+  #define TS_ONEWIRE_I2C
+  
+  // TS_ONEWIRE_PPWR: Specifies whether parasite power is used for OneWire temperature
+  // sensors. Parasite power allows sensors to obtain their power from the data line
+  // but significantly increases the time required to read the temperature (94-750ms
+  // based on resolution versus 10ms with dedicated power).
+  #define TS_ONEWIRE_PPWR 0
+  
+  // TS_ONEWIRE_RES: OneWire Temperature Sensor Resolution (9-bit - 12-bit). Valid
+  // options are: 9, 10, 11, 12). Unless parasite power is being used the recommended
+  // setting is 12-bit (for DS18B20 sensors). DS18S20 sensors can only operate at a max
+  // of 9 bit. When using parasite power decreasing the resolution reduces the 
+  // temperature conversion time: 
+  //   12-bit (0.0625C / 0.1125F) = 750ms 
+  //   11-bit (0.125C  / 0.225F ) = 375ms 
+  //   10-bit (0.25C   / 0.45F  ) = 188ms 
+  //    9-bit (0.5C    / 0.9F   ) =  94ms   
+  #define TS_ONEWIRE_RES 11
+  
+  // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
+  // 2 bytes of temperature data and ignoring CRC check.
+  #define TS_ONEWIRE_FASTREAD
+  
+  // DS2482_ADDR: I2C Address of DS2482 OneWire Master (used for TS_OneWire_I2C)
+  // Should be 0x18, 0x19, 0x1A, 0x1B
+  #define DS2482_ADDR 0x1B
+  //**********************************************************************************
+
+
+  //**********************************************************************************
+  // Serial0 Communication Options
+  //**********************************************************************************
+  // COM_SERIAL0: Specifies the communication type being used (Pick One):
+  //  ASCII  = Original BrewTroller serial command protocol used with BTRemote and BTLog
+  //  BTNIC  = BTnic (Lighterweight implementation of ASCII protocol using single-byte
+  //           commands. This protocol is used with BTnic Modules and software for
+  //           network connectivity.
+  //  BINARY = Binary Messages
+  //**********************************************************************************
+  
+  //#define COM_SERIAL0  ASCII
+  #define COM_SERIAL0  BTNIC
+  //#define COM_SERIAL0 BINARY
+  
+  // BAUD_RATE: The baud rate for the Serial0 connection. Previous to BrewTroller 2.0
+  // Build 419 this was hard coded to 9600. Starting with Build 419 the default rate
+  // was increased to 115200 but can be manually set using this compile option.
+  #define SERIAL0_BAUDRATE 115200
+
+#endif
+
+

--- a/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
+++ b/src/HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h
@@ -1,0 +1,124 @@
+/*
+BrewTroller Phoenix Steam/PWM Pump Hardware Configuration
+*/
+
+#ifndef __BREWTROLLER_HWPROFILE__
+    #error "Include HardwareProfile.h instead of this file"
+#endif
+
+#ifndef BT_HWPROFILE
+#define BT_HWPROFILE
+
+  #define ENCODER_I2C
+  #define ENCODER_I2CADDR 0x01
+
+  #define ALARM_PIN 15 //OUT4
+  
+  #define PVOUT_TYPE_MUX
+  #define PVOUT_COUNT 16 //16 Outputs
+
+  #define MUX_LATCH_PIN 3
+  #define MUX_CLOCK_PIN 4
+  #define MUX_DATA_PIN 1
+  #define MUX_ENABLE_PIN 2
+  #define MUX_ENABLE_LOGIC 0
+  
+  #define HLTHEAT_PIN 12
+  #define MASHHEAT_PIN 13
+  #define KETTLEHEAT_PIN 14
+  #define STEAMHEAT_PIN 15
+  #define PWMPUMP_PIN 15
+
+  #define DIGITAL_INPUTS
+  #define DIGIN_COUNT 8
+  #define DIGIN1_PIN 31
+  #define DIGIN2_PIN 30
+  #define DIGIN3_PIN 29
+  #define DIGIN4_PIN 28
+  #define DIGIN5_PIN 18
+  #define DIGIN6_PIN 19
+  #define DIGIN7_PIN 20
+  #define DIGIN8_PIN 21
+
+  #define RS485_SERIAL_PORT 1
+  #define RS485_RTS_PIN    23
+  #define PVOUT_TYPE_MODBUS
+  
+  #define HLTVOL_APIN 7
+  #define MASHVOL_APIN 6
+  #define KETTLEVOL_APIN 5
+  #define STEAMPRESS_APIN 4
+  
+  #define UI_LCD_I2C
+  #define UI_LCD_I2CADDR 0x01
+  #define UI_DISPLAY_SETUP
+  #define LCD_DEFAULT_CONTRAST 100
+  #define LCD_DEFAULT_BRIGHTNESS 255
+  
+  // BTPD_SUPPORT: Enables use of BrewTroller PID Display devices on I2C bus
+  #define BTPD_SUPPORT
+  
+  // BTNIC_EMBEDDED: Enables use of on-board I2C Ethernet module
+  #define BTNIC_EMBEDDED
+  
+  #define HEARTBEAT
+  #define HEARTBEAT_PIN 0
+
+  //**********************************************************************************
+  // OneWire Temperature Sensor Options
+  //**********************************************************************************
+  // TS_ONEWIRE: Enables use of OneWire Temperature Sensors
+  // TS_ONEWIRE_I2C: Enables use of DS2482 I2C 1-Wire Bus Master
+  #define TS_ONEWIRE
+  #define TS_ONEWIRE_I2C
+  
+  // TS_ONEWIRE_PPWR: Specifies whether parasite power is used for OneWire temperature
+  // sensors. Parasite power allows sensors to obtain their power from the data line
+  // but significantly increases the time required to read the temperature (94-750ms
+  // based on resolution versus 10ms with dedicated power).
+  #define TS_ONEWIRE_PPWR 0
+  
+  // TS_ONEWIRE_RES: OneWire Temperature Sensor Resolution (9-bit - 12-bit). Valid
+  // options are: 9, 10, 11, 12). Unless parasite power is being used the recommended
+  // setting is 12-bit (for DS18B20 sensors). DS18S20 sensors can only operate at a max
+  // of 9 bit. When using parasite power decreasing the resolution reduces the 
+  // temperature conversion time: 
+  //   12-bit (0.0625C / 0.1125F) = 750ms 
+  //   11-bit (0.125C  / 0.225F ) = 375ms 
+  //   10-bit (0.25C   / 0.45F  ) = 188ms 
+  //    9-bit (0.5C    / 0.9F   ) =  94ms   
+  #define TS_ONEWIRE_RES 11
+  
+  // TS_ONEWIRE_FASTREAD: Enables faster reads of temperatures by reading only the first
+  // 2 bytes of temperature data and ignoring CRC check.
+  #define TS_ONEWIRE_FASTREAD
+  
+  // DS2482_ADDR: I2C Address of DS2482 OneWire Master (used for TS_OneWire_I2C)
+  // Should be 0x18, 0x19, 0x1A, 0x1B
+  #define DS2482_ADDR 0x1B
+  //**********************************************************************************
+
+
+  //**********************************************************************************
+  // Serial0 Communication Options
+  //**********************************************************************************
+  // COM_SERIAL0: Specifies the communication type being used (Pick One):
+  //  ASCII  = Original BrewTroller serial command protocol used with BTRemote and BTLog
+  //  BTNIC  = BTnic (Lighterweight implementation of ASCII protocol using single-byte
+  //           commands. This protocol is used with BTnic Modules and software for
+  //           network connectivity.
+  //  BINARY = Binary Messages
+  //**********************************************************************************
+  
+  //#define COM_SERIAL0  ASCII
+  #define COM_SERIAL0  BTNIC
+  //#define COM_SERIAL0 BINARY
+  
+  // BAUD_RATE: The baud rate for the Serial0 connection. Previous to BrewTroller 2.0
+  // Build 419 this was hard coded to 9600. Starting with Build 419 the default rate
+  // was increased to 115200 but can be manually set using this compile option.
+  #define SERIAL0_BAUDRATE 115200
+
+#endif
+
+

--- a/src/HardwareProfile.h
+++ b/src/HardwareProfile.h
@@ -69,6 +69,8 @@ Documentation, Forums and more information available at http://www.brewtroller.c
 #elif defined(OT_EX1_STEAMPWM)
     #include "HWProfiles/OpenTroller EX1/Steam or PWM Pump/HWProfile.h"
 
+#elif defined(BT_PHOENIX)
+    #include "HWProfiles/BrewTroller Phoenix/HWProfile.h"
 #else
     #if !defined(BT_HWPROFILE)
         #error "BrewTroller Hardware type not defined"

--- a/src/HardwareProfile.h
+++ b/src/HardwareProfile.h
@@ -69,8 +69,14 @@ Documentation, Forums and more information available at http://www.brewtroller.c
 #elif defined(OT_EX1_STEAMPWM)
     #include "HWProfiles/OpenTroller EX1/Steam or PWM Pump/HWProfile.h"
 
-#elif defined(BT_PHOENIX)
-    #include "HWProfiles/BrewTroller Phoenix/HWProfile.h"
+#elif defined(BT_PHOENIX_HERMS)
+    #include "HWProfiles/BrewTroller Phoenix/HERMS/HWProfile.h"
+#elif defined(BT_PHOENIX_RIMS)
+    #include "HWProfiles/BrewTroller Phoenix/RIMS or Direct Fired/HWProfile.h"
+#elif defined(BT_PHOENIX_SINGLE_VESSEL)
+    #include "HWProfiles/BrewTroller Phoenix/Single Vessel/HWProfile.h"
+#elif defined(BT_PHOENIX_STEAM_PWM)
+    #include "HWProfiles/BrewTroller Phoenix/Steam or PWM Pump/HWProfile.h"
 #else
     #if !defined(BT_HWPROFILE)
         #error "BrewTroller Hardware type not defined"


### PR DESCRIPTION
The PR adds:
- Board configs for BT Phoenix (contributed to brewtrollergit by jvetter1)
- Updated CMake configs for the new profiles
- Updated travis build-all-test script to add baseline builds for all new phoenix profiles
