### PR TITLE
Support for auto-generated RGBIO config from a JSON file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,3 +38,16 @@ include_directories(lib/arduino
 
 add_subdirectory(lib)
 add_subdirectory(src)
+
+if(EXISTS "rgbio.json")
+    message(STATUS "Auto-generating RGBIO config")
+    execute_process(COMMAND python json2mako.py -j rgbio.json -t templates/rgbio.template -o src/Com_RGBIO8_Config.h
+	                ERROR_VARIABLE rgb_stderr
+	                RESULT_VARIABLE rgb_result_var
+					ERROR_STRIP_TRAILING_WHITESPACE)
+    if (NOT "${rgb_result_var}" STREQUAL "0")
+	    message(FATAL_ERROR "${rgb_stderr}")
+	else()
+		add_definitions("-DGENERATED_RGBIO_CONFIG")
+	endif()
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,12 @@ add_subdirectory(src)
 if(EXISTS "rgbio.json")
     message(STATUS "Auto-generating RGBIO config")
     execute_process(COMMAND python json2mako.py -j rgbio.json -t templates/rgbio.template -o src/Com_RGBIO8_Config.h
-	                ERROR_VARIABLE rgb_stderr
-	                RESULT_VARIABLE rgb_result_var
-					ERROR_STRIP_TRAILING_WHITESPACE)
+                    ERROR_VARIABLE rgb_stderr
+                    RESULT_VARIABLE rgb_result_var
+                    ERROR_STRIP_TRAILING_WHITESPACE)
     if (NOT "${rgb_result_var}" STREQUAL "0")
-	    message(FATAL_ERROR "${rgb_stderr}")
-	else()
-		add_definitions("-DGENERATED_RGBIO_CONFIG")
-	endif()
+        message(FATAL_ERROR "${rgb_stderr}")
+    else()
+        add_definitions("-DGENERATED_RGBIO_CONFIG")
+    endif()
 endif()

--- a/json2mako.py
+++ b/json2mako.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python2.7
+
+from __future__ import print_function
+
+import os
+import sys
+import json
+import argparse
+import traceback
+
+from mako.template import Template
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='BT JSON to CPP converted')
+    parser.add_argument('-j','--json',     dest='json',     required=True, default=None, help='JSON input file')
+    parser.add_argument('-t','--template', dest='template', required=True, default=None, help='Make Template Input File')
+    parser.add_argument('-o','--output',   dest='output',   required=True, default=None, help='JSON input file')
+    return parser.parse_args()
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    try:
+        with open(args.json) as json_file:
+            json_data = json.load(json_file)
+    except Exception as exp:
+        eprint("Unable to load JSON file '%s'" % args.json)
+        eprint(exp)
+        sys.exit(2)
+
+    try:
+        template = Template(filename=args.template)
+    except Exception as exp:
+        eprint("Unable to open MAKO template '%s'" % args.template )
+        eprint(exp)
+        sys.exit(3)
+
+    try:
+        with open(args.output, 'w') as output_file:
+           output_file.write(template.render(json=json_data))
+    except Exception as exp:
+        eprint("Unable to create output file '%s'" % args.output)
+        eprint(exp)
+        sys.exit(4)
+

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ set(ENUM_HEADER "${CMAKE_CURRENT_LIST_DIR}/Enum.h")
 execute_process(COMMAND git describe --tags --abbrev=0
                 OUTPUT_VARIABLE VER_STR
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 message(STATUS "Building BrewTroller version: " ${VER_STR})
 
 ####################
@@ -75,6 +76,10 @@ BT_PHOENIX_SINGLE_VESSEL --> Phoenix Single Vessel
 BT_PHOENIX_STEAM_PWM     --> Phoenix Steam or PWM Pump") # Default to DX1 Herms build
 add_definitions("-D${board}")
 message(STATUS "Building BrewTroller for   " ${board})
+
+if (EXISTS "src/Com_RGBIO8_Config.h")
+	add_definitions("-DGENERATED_RGBIO_CONFIG")
+endif()
 
 #####
 # Basic Options

--- a/src/Com_RGBIO8.cpp
+++ b/src/Com_RGBIO8.cpp
@@ -1,5 +1,6 @@
 #include "Com_RGBIO8.h"
 #include "Outputs.h"
+#include "Util.h"
 
 #ifdef RGBIO8_ENABLE
 
@@ -124,6 +125,12 @@ RGBIO8::RGBIO8() {
     output_assignments[i].type = 0;
     input_assignments[i].type = 0;
   }
+#ifdef GENERATED_RGBIO_CONFIG
+  #pragma message "Using generated RGBIO8 config"
+  memcpy(RGBIO8::output_recipes, genRGBIO_OutputRecipes, array_size(genRGBIO_Inputs) * sizeof(uint16_t) * 4);
+  memcpy(output_assignments, genRGBIO_Outputs, array_size(genRGBIO_Inputs) * sizeof(RGBIO8_output_assignment));
+  memcpy(input_assignments, genRGBIO_Inputs, array_size(genRGBIO_Inputs) * sizeof(RGBIO8_input_assignment));
+#endif
 }
 
 void RGBIO8::begin(int rs485_address, int i2c_address) {

--- a/src/Com_RGBIO8.h
+++ b/src/Com_RGBIO8.h
@@ -4,6 +4,21 @@
 #include "BrewTroller.h"
 #include "Config.h"
 
+struct RGBIO8_output_assignment {
+    byte type;
+    byte index;
+    byte recipe_id;
+};
+
+struct RGBIO8_input_assignment {
+    byte type;
+    byte index;
+};
+
+#ifdef GENERATED_RGBIO_CONFIG
+#include "Com_RGBIO8_Config.h"
+#endif
+
 #ifdef RGBIO8_ENABLE
 
 #define RGBIO8_MAX_OUTPUT_RECIPES 4
@@ -15,17 +30,6 @@
 
 extern byte softSwitchHeat[HEAT_OUTPUTS_COUNT];
 extern byte softSwitchPv[PVOUT_COUNT];
-
-struct RGBIO8_output_assignment {
-  byte type;
-  byte index;
-  byte recipe_id;
-};
-
-struct RGBIO8_input_assignment {
-  byte type;
-  byte index;
-};
 
 class RGBIO8 {
   public:

--- a/src/Config.in.h
+++ b/src/Config.in.h
@@ -681,6 +681,12 @@ static const uint8_t TS = 1;
 //
 #define RGBIO8_NUM_BOARDS 1
 //
+
+#ifdef GENERATED_RGBIO_CONFIG
+#define RGBIO8_ENABLE
+#endif
+
+
 //**********************************************************************************
 
 #endif

--- a/src/Util.h
+++ b/src/Util.h
@@ -11,4 +11,9 @@ void vftoa(unsigned long val, char retStr[], unsigned int divisor, boolean decim
 unsigned long pow10(byte power);
 unsigned long pow2(byte power);
 
+template<class T, size_t N>
+constexpr size_t array_size(T(&)[N]) { return N; }
+template<class T, size_t N, size_t M>
+constexpr size_t array_size(T(&)[N][M]) { return N; }
+
 #endif

--- a/templates/rgbio.template
+++ b/templates/rgbio.template
@@ -1,0 +1,40 @@
+<%
+    from operator import itemgetter
+
+    recipes = json['recipes']
+    inputs = sorted(json['assignments'],key=itemgetter('input'), reverse=True)
+    outputs = sorted(json['assignments'],key=itemgetter('output'), reverse=True)
+%>
+#ifndef COM_RGBIO8_CONFIG_H
+#define COM_RGBIO8_CONFIG_H
+
+#include "Com_RGBIO8.h"
+
+#undef RGBIO_NUM_BOARDS
+#undef RGBIO_SETUP
+#undef RGBIO_START_ADDR
+
+#define RGBIO_NUM_BOARDS ${json['boards']}
+% if json['enable_setup']:
+#define RGBIO_SETUP
+% endif
+#define RGBIO_START_ADDR ${json['start_address']}
+
+const uint16_t genRGBIO_OutputRecipes[${len(recipes)}][4] = {
+% for r in recipes:
+    {${r['off_rgb']},${r['auto_off_rgb']},${r['auto_on_rgb']},${r['on_rgb']}},
+% endfor
+} ;
+
+const RGBIO8_output_assignment genRGBIO_Outputs[${len(outputs)}] = {
+% for o in outputs:
+    {${o['type']}, ${o['vessel'] if o['type'] == 1 else o['pv']}, ${o['recipe']}},
+% endfor
+};
+
+const RGBIO8_input_assignment genRGBIO_Inputs[${len(inputs)}] = {
+% for i in inputs:
+    {${o['type']}, ${o['vessel'] if o['type'] == 1 else o['pv']}},
+% endfor
+};
+#endif

--- a/test/rgbio.json
+++ b/test/rgbio.json
@@ -1,0 +1,37 @@
+{
+    "boards" : 3,
+    "enable_setup" : true,
+    "start_address" : 48,
+    "recipes" : [
+        {
+          "off_rgb"      : 3840,
+          "auto_off_rgb" : 4095,
+          "auto_on_rgb"  : 3904,
+          "on_rgb"       : 240
+        },
+        {
+          "off_rgb"      : 3840,
+          "auto_off_rgb" : 4095,
+          "auto_on_rgb"  : 15,
+          "on_rgb"       : 240
+        }
+    ],
+    "assignments" : [
+        {
+            "type"  : 1,
+            "board" : 0,
+            "vessel" : 0,
+            "input" : 0,
+            "output" : 0,
+            "recipe" : 0
+        },
+        {
+            "type"  : 2,
+            "board" : 1,
+            "pv"    : 2,
+            "input" : 3,
+            "output" : 3,
+            "recipe" : 1
+        }
+    ]
+}


### PR DESCRIPTION
Changes are as follows:
- At CMAKE config time, if the rgbio.json is detected, it runs the python script json2mako.py using the new rgbio.template
- If successful, a new Com_RGBIO8_Config.h files gets generated with the config parsed from the JSON file. In addition the GENERATE_RGBIO_CONFIG define gets set
- When Config.in detects this define it enabled the RGB code
- When the RGB coded detected the define, its loads the config using the generated arrays in the new header
- Voilà